### PR TITLE
Expand cmake config (search for libcurl & libtwili, building .kip and .nsp)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,29 @@ if (NOT LIBNX_FOUND)
     cmake_panic("Unable to detect libnx on this system.")
 endif ()
 
+# === The following 3 libs are required for cURL ===
+# === Add ${CURL_LIBRARIES} ${MBEDTLS_LIBRARIES} ${ZLIB_LIBRARIES} to target_link_libraries() before switch::libnx ===
+
+# find_package(CURL REQUIRED)
+# if (NOT CURL_FOUND)
+#     cmake_panic("Unable to detect libcurl on this system.")
+# endif ()
+# find_package(ZLIB REQUIRED)
+# if (NOT ZLIB_FOUND)
+#     cmake_panic("Unable to detect zlib on this system.")
+# endif ()
+# find_package(MbedTLS REQUIRED)
+# if (NOT MbedTLS_FOUND)
+#     cmake_panic("Unable to detect mbedtls on this system.")
+# endif ()
+
+# === Add switch::libtwili to target_link_libraries() to link with libtwili ===
+
+# find_package(LIBTWILI REQUIRED)
+# if (NOT LIBTWILI_FOUND)
+#     cmake_panic("Unable to detect libtwili on this system.")
+# endif ()
+
 include_directories(${PROJECT_BINARY_DIR})
 
 # Replace this with the name of your application
@@ -59,3 +82,5 @@ set_target_properties(${HOMEBREW_APP}.elf PROPERTIES
         LINK_FLAGS "-specs=${LIBNX}/switch.specs -Wl,-no-as-needed -Wl,-Map,.map")
 
 build_switch_binaries(${HOMEBREW_APP}.elf)
+# build_switch_sysmodule(${HOMEBREW_APP}.elf)  # build .kip
+# build_switch_nsp(${HOMEBREW_APP}.elf)  # build .nsp

--- a/cmake/FindLIBTWILI.cmake
+++ b/cmake/FindLIBTWILI.cmake
@@ -1,0 +1,40 @@
+# Tries to find libtwili
+# Once done, this will define:
+# > LIBTWILI_FOUND - The system has libtwili
+# > LIBTWILI_INCLUDE_DIRS - The libtwili include directories
+# > LIBTWILI_LIBRARIES - The libtwili libraries required for using it
+#
+# It also adds an imported target named `switch::libtwili`.
+
+if (NOT SWITCH)
+    cmake_panic("This helper can only be used if you are using the Switch toolchain file.")
+endif ()
+
+set(LIBTWILI_PATHS $ENV{LIBTWILI} libtwili ${LIBTWILI} ${PORTLIBS})
+
+find_path(LIBTWILI_INCLUDE_DIR twili.h
+        PATHS ${LIBTWILI_PATHS}
+        PATH_SUFFIXES include)
+
+find_library(LIBTWILI_LIBRARY NAMES libtwili.a
+        PATHS ${LIBTWILI_PATHS}
+        PATH_SUFFIXES lib)
+
+set(LIBTWILI_INCLUDE_DIRS ${LIBTWILI_INCLUDE_DIR})
+set(LIBTWILI_LIBRARIES ${LIBTWILI_LIBRARY})
+
+# Handle the QUIETLY and REQUIRED arguments and set LIBTWILI_FOUND to TRUE if all above variables are TRUE.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LIBTWILI DEFAULT_MSG
+        LIBTWILI_INCLUDE_DIR LIBTWILI_LIBRARY)
+
+mark_as_advanced(LIBTWILI_INCLUDE_DIR LIBTWILI_LIBRARY)
+if (LIBTWILI_FOUND)
+    set(LIBTWILI ${LIBTWILI_INCLUDE_DIR}/..)
+    cmake_info("Setting LIBTWILI to ${LIBTWILI}")
+
+    add_library(switch::libtwili STATIC IMPORTED GLOBAL)
+    set_target_properties(switch::libtwili PROPERTIES
+            IMPORTED_LOCATION ${LIBTWILI_LIBRARY}
+            INTERFACE_INCLUDE_DIRECTORIES ${LIBTWILI_INCLUDE_DIR})
+endif ()

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -1,0 +1,90 @@
+############################################################################
+# FindMdebTLS.txt
+# Copyright (C) 2015  Belledonne Communications, Grenoble France
+#
+############################################################################
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+############################################################################
+#
+# - Find the mbedTLS include file and library
+#
+#  MBEDTLS_FOUND - system has mbedTLS
+#  MBEDTLS_INCLUDE_DIRS - the mbedTLS include directory
+#  MBEDTLS_LIBRARIES - The libraries needed to use mbedTLS
+
+include(CMakePushCheckState)
+include(CheckIncludeFile)
+include(CheckCSourceCompiles)
+include(CheckSymbolExists)
+
+
+find_path(MBEDTLS_INCLUDE_DIRS
+	NAMES mbedtls/ssl.h
+	PATH_SUFFIXES include
+)
+
+# find the three mbedtls library
+find_library(MBEDTLS_LIBRARY
+	NAMES mbedtls
+)
+
+find_library(MBEDX509_LIBRARY
+	NAMES mbedx509
+)
+
+find_library(MBEDCRYPTO_LIBRARY
+	NAMES mbedcrypto
+)
+
+cmake_push_check_state(RESET)
+set(CMAKE_REQUIRED_INCLUDES ${MBEDTLS_INCLUDE_DIRS} ${CMAKE_REQUIRED_INCLUDES_${BUILD_TYPE}})
+list(APPEND CMAKE_REQUIRED_LIBRARIES ${MBEDTLS_LIBRARY} ${MBEDX509_LIBRARY} ${MBEDCRYPTO_LIBRARY})
+
+# check we have a mbedTLS version 2 or above(all functions are prefixed mbedtls_)
+if(MBEDTLS_LIBRARY AND MBEDX509_LIBRARY AND MBEDCRYPTO_LIBRARY)
+	check_symbol_exists(mbedtls_ssl_init "mbedtls/ssl.h" MBEDTLS_V2)
+  if(MBEDTLS_V2)
+	  set (MBEDTLS_LIBRARIES
+		  ${MBEDTLS_LIBRARY}
+		  ${MBEDX509_LIBRARY}
+		  ${MBEDCRYPTO_LIBRARY}
+	  )
+  else()
+    message ("MESSAGE: NO MBEDTLS_V2")
+    message ("MESSAGE: MBEDTLS_LIBRARY=" ${MBEDTLS_LIBRARY})
+    message ("MESSAGE: MBEDX509_LIBRARY=" ${MBEDX509_LIBRARY})
+    message ("MESSAGE: MBEDCRYPTO_LIBRARY=" ${MBEDCRYPTO_LIBRARY})
+    
+  endif()
+
+endif()
+
+if(MBEDTLS_LIBRARIES)
+	check_symbol_exists(mbedtls_ssl_get_dtls_srtp_protection_profile "mbedtls/ssl.h" HAVE_SSL_GET_DTLS_SRTP_PROTECTION_PROFILE)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MbedTLS
+	DEFAULT_MSG
+	MBEDTLS_INCLUDE_DIRS MBEDTLS_LIBRARIES
+)
+
+cmake_pop_check_state()
+
+
+
+mark_as_advanced(MBEDTLS_INCLUDE_DIRS MBEDTLS_LIBRARIES HAVE_SSL_GET_DTLS_SRTP_PROTECTION_PROFILE)


### PR DESCRIPTION
I've used this template and extended it for building sysmodules (.nsp): https://github.com/bakatrouble/sys-screenuploader
There are commented examples for libs usage in root `CMakeLists.txt`.
I've also ported .kip building code, but didn't test it.